### PR TITLE
Polish landing page with Lamborghini-inspired orange theme and visual refinements

### DIFF
--- a/src/landing/src/components/content/FeatureCard.tsx
+++ b/src/landing/src/components/content/FeatureCard.tsx
@@ -15,6 +15,8 @@ const useStyles = makeStyles({
     flexDirection: "column",
     ...shorthands.gap("1.25rem"),
     backgroundColor: tokens.colorNeutralBackground1,
+    backgroundImage: "linear-gradient(135deg, rgba(255,107,0,0.12), transparent 60%)",
+    ...shorthands.border("1px", "solid", "rgba(255, 107, 0, 0.2)"),
     boxShadow: tokens.shadow4,
     ...shorthands.borderRadius(tokens.borderRadiusLarge),
     ...shorthands.transition("all", "0.2s", "ease-in-out"),

--- a/src/landing/src/components/content/PricingCard.tsx
+++ b/src/landing/src/components/content/PricingCard.tsx
@@ -17,14 +17,21 @@ const useStyles = makeStyles({
     flexDirection: "column",
     ...shorthands.gap("1.5rem"),
     backgroundColor: tokens.colorNeutralBackground1,
+    backgroundImage: "linear-gradient(160deg, rgba(255,107,0,0.18), transparent 65%)",
+    ...shorthands.border("1px", "solid", "rgba(255, 107, 0, 0.25)"),
     position: "relative",
     boxShadow: tokens.shadow4,
     ...shorthands.borderRadius(tokens.borderRadiusLarge),
     ...shorthands.transition("all", "0.2s", "ease-in-out"),
     ...shorthands.overflow("visible"),
+    ":hover": {
+      boxShadow: tokens.shadow16,
+      transform: "translateY(-4px)",
+    },
   },
   cardHighlighted: {
     ...shorthands.border("2px", "solid", tokens.colorBrandForeground1),
+    backgroundImage: "linear-gradient(160deg, rgba(255,107,0,0.3), rgba(8,8,8,0.95) 70%)",
     boxShadow: tokens.shadow16,
     transform: "scale(1.03)",
     "@media (max-width: 768px)": {
@@ -69,7 +76,7 @@ const useStyles = makeStyles({
     alignItems: "flex-start",
   },
   featureIcon: {
-    color: tokens.colorPaletteGreenForeground1,
+    color: tokens.colorBrandForeground2,
     flexShrink: 0,
     marginTop: "2px",
   },

--- a/src/landing/src/components/content/StatCard.tsx
+++ b/src/landing/src/components/content/StatCard.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, Text, tokens } from "@fluentui/react-components";
+import { makeStyles, shorthands, Text, tokens } from "@fluentui/react-components";
 import * as FluentIcons from "@fluentui/react-icons";
 
 interface StatCardProps {
@@ -14,7 +14,16 @@ const useStyles = makeStyles({
     alignItems: "center",
     textAlign: "center",
     gap: "0.875rem",
-    padding: "1rem",
+    padding: "1.5rem",
+    backgroundColor: tokens.colorNeutralBackground1,
+    ...shorthands.border("1px", "solid", "rgba(255, 107, 0, 0.25)"),
+    ...shorthands.borderRadius(tokens.borderRadiusLarge),
+    boxShadow: tokens.shadow4,
+    ...shorthands.transition("all", "0.2s", "ease-in-out"),
+    ":hover": {
+      boxShadow: tokens.shadow16,
+      transform: "translateY(-4px)",
+    },
   },
   iconWrapper: {
     fontSize: "32px",

--- a/src/landing/src/components/cta/ContactForm.tsx
+++ b/src/landing/src/components/cta/ContactForm.tsx
@@ -30,6 +30,7 @@ const useStyles = makeStyles({
   submitButton: {
     marginTop: "0.5rem",
     width: "100%",
+    boxShadow: "0 10px 30px rgba(255, 107, 0, 0.25)",
     "@media (min-width: 768px)": {
       width: "auto",
       minWidth: "200px",

--- a/src/landing/src/components/sections/CTASection.tsx
+++ b/src/landing/src/components/sections/CTASection.tsx
@@ -5,6 +5,10 @@ import ContactForm from "../cta/ContactForm";
 import { ctaSection } from "../../data/content";
 
 const useStyles = makeStyles({
+  section: {
+    position: "relative",
+    background: "radial-gradient(circle at top right, rgba(255,107,0,0.14), transparent 60%)",
+  },
   content: {
     display: "flex",
     flexDirection: "column",
@@ -45,6 +49,12 @@ const useStyles = makeStyles({
   formContainer: {
     width: "100%",
     maxWidth: "700px",
+    backgroundColor: tokens.colorNeutralBackground1,
+    ...shorthands.padding("2rem"),
+    ...shorthands.borderRadius(tokens.borderRadiusLarge),
+    ...shorthands.border("1px", "solid", "rgba(255, 107, 0, 0.25)"),
+    boxShadow: tokens.shadow8,
+    backgroundImage: "linear-gradient(160deg, rgba(255,107,0,0.12), transparent 65%)",
   },
 });
 
@@ -52,7 +62,7 @@ export default function CTASection() {
   const styles = useStyles();
 
   return (
-    <Section id="contact" backgroundColor="subtle" paddingSize="large">
+    <Section id="contact" backgroundColor="subtle" paddingSize="large" className={styles.section}>
       <Container maxWidth="medium">
         <div className={styles.content}>
           <div className={styles.header}>

--- a/src/landing/src/components/sections/FeaturesSection.tsx
+++ b/src/landing/src/components/sections/FeaturesSection.tsx
@@ -7,6 +7,10 @@ import { features } from "../../data/content";
 import * as FluentIcons from "@fluentui/react-icons";
 
 const useStyles = makeStyles({
+  section: {
+    position: "relative",
+    background: "radial-gradient(circle at top left, rgba(255,107,0,0.1), transparent 55%)",
+  },
   header: {
     textAlign: "center",
     marginBottom: "3rem",
@@ -45,7 +49,7 @@ export default function FeaturesSection() {
   const styles = useStyles();
 
   return (
-    <Section id="features" paddingSize="large">
+    <Section id="features" paddingSize="large" className={styles.section}>
       <Container>
         <div className={styles.header}>
           <Text className={styles.title}>Production-Ready Infrastructure</Text>

--- a/src/landing/src/components/sections/HeroSection.tsx
+++ b/src/landing/src/components/sections/HeroSection.tsx
@@ -10,6 +10,32 @@ const useStyles = makeStyles({
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
+    position: "relative",
+    ...shorthands.overflow("hidden"),
+    "::before": {
+      content: '""',
+      position: "absolute",
+      top: "-30%",
+      left: "-10%",
+      width: "55%",
+      height: "70%",
+      background: "radial-gradient(circle, rgba(255,107,0,0.35), transparent 70%)",
+      filter: "blur(10px)",
+      opacity: 0.9,
+      pointerEvents: "none",
+    },
+    "::after": {
+      content: '""',
+      position: "absolute",
+      bottom: "-35%",
+      right: "-10%",
+      width: "60%",
+      height: "80%",
+      background: "radial-gradient(circle, rgba(255,179,80,0.25), transparent 70%)",
+      filter: "blur(20px)",
+      opacity: 0.8,
+      pointerEvents: "none",
+    },
   },
   heroContent: {
     maxWidth: "1100px",
@@ -20,6 +46,18 @@ const useStyles = makeStyles({
     flexDirection: "column",
     ...shorthands.gap("2rem"),
     alignItems: "center",
+    position: "relative",
+    zIndex: 1,
+  },
+  eyebrow: {
+    fontSize: tokens.fontSizeBase300,
+    letterSpacing: "0.2em",
+    textTransform: "uppercase",
+    color: tokens.colorBrandForeground2,
+    backgroundColor: "rgba(255, 107, 0, 0.12)",
+    ...shorthands.padding("0.4rem", "1.1rem"),
+    ...shorthands.borderRadius("999px"),
+    border: `1px solid ${tokens.colorBrandForeground2}`,
   },
   headline: {
     fontSize: "2.5rem",
@@ -50,6 +88,25 @@ const useStyles = makeStyles({
       fontSize: tokens.fontSizeBase500,
     },
   },
+  highlights: {
+    display: "flex",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    ...shorthands.gap("0.75rem"),
+    marginTop: "0.5rem",
+  },
+  highlightPill: {
+    fontSize: tokens.fontSizeBase300,
+    color: tokens.colorNeutralForeground1,
+    backgroundColor: "rgba(16, 16, 16, 0.85)",
+    ...shorthands.padding("0.5rem", "0.9rem"),
+    ...shorthands.borderRadius("999px"),
+    border: `1px solid ${tokens.colorNeutralStroke1}`,
+    boxShadow: tokens.shadow4,
+    "@media (min-width: 768px)": {
+      fontSize: tokens.fontSizeBase400,
+    },
+  },
   ctaGroup: {
     display: "flex",
     flexDirection: "column",
@@ -69,6 +126,7 @@ export default function HeroSection() {
     <Section paddingSize="large" className={styles.hero}>
       <Container maxWidth="large">
         <div className={styles.heroContent}>
+          <Text className={styles.eyebrow}>Inference Bros</Text>
           <Text className={styles.headline}>{heroContent.headline}</Text>
           <div className={styles.subheadline}>
             {Array.isArray(heroContent.subheadline)
@@ -80,6 +138,15 @@ export default function HeroSection() {
               : <Text>{heroContent.subheadline}</Text>
             }
           </div>
+          {heroContent.highlights && (
+            <div className={styles.highlights}>
+              {heroContent.highlights.map((highlight) => (
+                <Text key={highlight} className={styles.highlightPill}>
+                  {highlight}
+                </Text>
+              ))}
+            </div>
+          )}
           <div className={styles.ctaGroup}>
             <CTAButton variant="primary" href="#contact">
               {heroContent.primaryCTA}

--- a/src/landing/src/components/sections/PricingSection.tsx
+++ b/src/landing/src/components/sections/PricingSection.tsx
@@ -6,6 +6,10 @@ import PricingCard from "../content/PricingCard";
 import { pricingTiers } from "../../data/content";
 
 const useStyles = makeStyles({
+  section: {
+    position: "relative",
+    background: "radial-gradient(circle at top right, rgba(255,107,0,0.12), transparent 55%)",
+  },
   header: {
     textAlign: "center",
     marginBottom: "3rem",
@@ -60,7 +64,7 @@ export default function PricingSection() {
   };
 
   return (
-    <Section id="pricing" paddingSize="large">
+    <Section id="pricing" paddingSize="large" className={styles.section}>
       <Container maxWidth="large">
         <div className={styles.header}>
           <Text className={styles.title}>Flexible Pricing for Every Scale</Text>

--- a/src/landing/src/components/sections/StatsSection.tsx
+++ b/src/landing/src/components/sections/StatsSection.tsx
@@ -1,3 +1,4 @@
+import { makeStyles } from "@fluentui/react-components";
 import Section from "../layout/Section";
 import Container from "../layout/Container";
 import Grid from "../layout/Grid";
@@ -5,9 +6,18 @@ import StatCard from "../content/StatCard";
 import { stats } from "../../data/content";
 import * as FluentIcons from "@fluentui/react-icons";
 
+const useStyles = makeStyles({
+  section: {
+    position: "relative",
+    background: "linear-gradient(135deg, rgba(255,107,0,0.08), transparent 70%)",
+  },
+});
+
 export default function StatsSection() {
+  const styles = useStyles();
+
   return (
-    <Section backgroundColor="subtle" paddingSize="medium">
+    <Section backgroundColor="subtle" paddingSize="medium" className={styles.section}>
       <Container>
         <Grid columns={4} gap="large">
           {stats.map((stat, index) => (

--- a/src/landing/src/components/sections/UseCasesSection.tsx
+++ b/src/landing/src/components/sections/UseCasesSection.tsx
@@ -6,6 +6,10 @@ import { useCases } from "../../data/content";
 import * as FluentIcons from "@fluentui/react-icons";
 
 const useStyles = makeStyles({
+  section: {
+    position: "relative",
+    background: "radial-gradient(circle at bottom left, rgba(255,107,0,0.12), transparent 60%)",
+  },
   header: {
     textAlign: "center",
     marginBottom: "3rem",
@@ -45,6 +49,8 @@ const useStyles = makeStyles({
     ...shorthands.gap("1.25rem"),
     height: "100%",
     backgroundColor: tokens.colorNeutralBackground1,
+    backgroundImage: "linear-gradient(135deg, rgba(255,107,0,0.14), transparent 60%)",
+    ...shorthands.border("1px", "solid", "rgba(255, 107, 0, 0.25)"),
     boxShadow: tokens.shadow4,
     ...shorthands.borderRadius(tokens.borderRadiusLarge),
     ...shorthands.transition("all", "0.2s", "ease-in-out"),
@@ -75,7 +81,7 @@ export default function UseCasesSection() {
   const styles = useStyles();
 
   return (
-    <Section id="use-cases" backgroundColor="subtle" paddingSize="large">
+    <Section id="use-cases" backgroundColor="subtle" paddingSize="large" className={styles.section}>
       <Container>
         <div className={styles.header}>
           <Text className={styles.title}>Built for Intermediaries</Text>

--- a/src/landing/src/data/content.ts
+++ b/src/landing/src/data/content.ts
@@ -6,6 +6,11 @@ export const heroContent = {
     "Power your platform with production-ready AI infrastructure.",
     "Built on Kubernetes, optimized for performance, designed for intermediaries."
   ],
+  highlights: [
+    "Dedicated GPU pools with intelligent routing",
+    "OpenAI-compatible endpoints with enterprise controls",
+    "SLA-backed latency with real-time observability",
+  ],
   primaryCTA: "Request Demo",
   secondaryCTA: "View Documentation",
 };

--- a/src/landing/src/index.css
+++ b/src/landing/src/index.css
@@ -9,6 +9,7 @@ html {
   width: 100%;
   height: 100%;
   background-color: #0A0A0A;
+  background-image: radial-gradient(circle at top, rgba(255, 107, 0, 0.18), transparent 55%);
 }
 
 body {
@@ -18,6 +19,7 @@ body {
   height: 100%;
   overflow-x: hidden;
   background-color: #0A0A0A;
+  background-image: radial-gradient(circle at top, rgba(255, 107, 0, 0.18), transparent 55%);
   color: #FFFFFF;
 }
 
@@ -25,4 +27,5 @@ body {
   width: 100%;
   height: 100%;
   background-color: #0A0A0A;
+  background-image: radial-gradient(circle at top, rgba(255, 107, 0, 0.18), transparent 55%);
 }


### PR DESCRIPTION
### Motivation
- Refresh the Inference Bros landing to a more polished, high-impact visual style while keeping the orange "Lambo" branding and Fluent UI V9 design system.
- Add subtle depth and emphasis to hero, stats, pricing and CTA sections so the page reads as a premium product landing rather than a plain template.

### Description
- Elevated the hero with glow accents, an uppercase eyebrow badge, and highlight pills driven by new `heroContent.highlights` entries in `src/landing/src/data/content.ts` and layout updates in `src/landing/src/components/sections/HeroSection.tsx`.
- Introduced orange gradients, soft borders, hover lift and shadow polish across cards and sections by updating `FeatureCard.tsx`, `PricingCard.tsx`, `StatCard.tsx`, `UseCasesSection.tsx`, and `FeaturesSection.tsx` to reinforce the brand motif.
- Restyled the contact CTA by wrapping the form in a gradient-backed panel and adding a submit button shadow in `CTASection.tsx` and `ContactForm.tsx`, and added section-level radial/linear background accents to `StatsSection.tsx`, `PricingSection.tsx`, and `CTASection.tsx`.
- Applied a global radial background accent in `src/landing/src/index.css` and adjusted some icon/feature colors (e.g. pricing feature icon) to match the brand tokens.

### Testing
- Launched the local dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which started successfully and served the app at `http://localhost:4173/`.
- Captured a visual verification screenshot using a Playwright script which completed successfully and produced `artifacts/landing-page.png` for review.
- No unit or integration tests were added or run since changes are visual/UI-only and were validated via the live preview screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a6200bd0832e8f9313e042f595d5)